### PR TITLE
n8n version 0.65.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:12.16-alpine
+FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
-ARG N8N_VERSION=0.62.1
+ARG N8N_VERSION=0.65.0
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata


### PR DESCRIPTION
'request' module conflict resolved in this version, switching base Image to node:lts-alpine.
closes #8 