### PR TITLE
Missing login command for the container as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ set config vars(optional)
     heroku config:set N8N_BASIC_AUTH_USER=SET_USERNAME
     heroku config:set N8N_BASIC_AUTH_PASSWORD=SET_PASSWORD
 
+Login the container
+
+    heroku container:login
+
 build and push container image to heroku
 
     heroku container:push web --app APP_NAME


### PR DESCRIPTION
Without running "heroku container:login" you might encounter a "no basic auth credentials" error from Heroku side.
See https://github.com/fiorix/freegeoip/issues/171