### PR TITLE
v 1.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
 
-ARG N8N_VERSION=1.0.5
+ARG N8N_VERSION=1.1.1
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
-ARG N8N_VERSION=0.216.0
+ARG N8N_VERSION=0.217.2
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
-ARG N8N_VERSION=0.203.1
+ARG N8N_VERSION=0.211.2
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
 
-ARG N8N_VERSION=0.236.3
+ARG N8N_VERSION=1.0.5
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
-ARG N8N_VERSION=0.203.1
+ARG N8N_VERSION=0.216.0
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
-ARG N8N_VERSION=0.228.2
+ARG N8N_VERSION=0.230.3
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
 
-ARG N8N_VERSION=0.231.3
+ARG N8N_VERSION=0.233.1
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
 
-ARG N8N_VERSION=0.233.1
+ARG N8N_VERSION=0.236.2
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
-ARG N8N_VERSION=0.230.3
+ARG N8N_VERSION=0.231.3
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
-ARG N8N_VERSION=0.217.2
+ARG N8N_VERSION=0.228.2
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
 
-ARG N8N_VERSION=0.236.2
+ARG N8N_VERSION=0.236.3
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
 
-ARG N8N_VERSION=1.0.5
+ARG N8N_VERSION=1.1.1
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
-ARG N8N_VERSION=0.216.0
+ARG N8N_VERSION=0.217.2
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
-ARG N8N_VERSION=0.203.1
+ARG N8N_VERSION=0.211.2
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
 
-ARG N8N_VERSION=0.236.3
+ARG N8N_VERSION=1.0.5
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
-ARG N8N_VERSION=0.203.1
+ARG N8N_VERSION=0.216.0
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
-ARG N8N_VERSION=0.228.2
+ARG N8N_VERSION=0.230.3
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
 
-ARG N8N_VERSION=0.231.3
+ARG N8N_VERSION=0.233.1
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
 
-ARG N8N_VERSION=0.233.1
+ARG N8N_VERSION=0.236.2
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
-ARG N8N_VERSION=0.230.3
+ARG N8N_VERSION=0.231.3
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
-ARG N8N_VERSION=0.217.2
+ARG N8N_VERSION=0.228.2
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine
 
 # pass N8N_VERSION Argument while building or use default
 
-ARG N8N_VERSION=0.236.2
+ARG N8N_VERSION=0.236.3
 
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata


### PR DESCRIPTION
Just tested and works fine on a production instance.

Users should refer to https://docs.n8n.io/1-0-migration-checklist/ before upgrading.